### PR TITLE
Unify count setting logic as users endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3231,15 +3231,18 @@ public class SCIMUserManager implements UserManager {
     private Set<String> getGroupNamesForGroupsEndpoint(String domainName)
             throws UserStoreException, IdentitySCIMException {
 
-        String searchValue = SCIMCommonConstants.ANY;
-        if (StringUtils.isNotEmpty(domainName)) {
-            // If the domain is specified create a attribute value with the domain name.
-            searchValue = domainName + CarbonConstants.DOMAIN_SEPARATOR + SCIMCommonConstants.ANY;
+        if (StringUtils.isEmpty(domainName)) {
+            Set<String> groupsList = new HashSet<>(Arrays.asList(carbonUM.getRoleNames()));
+            // Remove roles.
+            groupsList.removeIf(SCIMCommonUtils::isHybridRole);
+            return groupsList;
+        } else {
+            String searchValue = domainName + CarbonConstants.DOMAIN_SEPARATOR + SCIMCommonConstants.ANY;
+            // Retrieve roles using the above attribute value.
+            List<String> roleList = Arrays
+                    .asList(carbonUM.getRoleNames(searchValue, MAX_ITEM_LIMIT_UNLIMITED, true, true, true));
+            return new HashSet<>(roleList);
         }
-        // Retrieve roles using the above attribute value.
-        List<String> roleList = Arrays
-                .asList(carbonUM.getRoleNames(searchValue, MAX_ITEM_LIMIT_UNLIMITED, true, true, true));
-        return new HashSet<>(roleList);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3049,6 +3049,8 @@ public class SCIMUserManager implements UserManager {
         startIndex = handleStartIndexEqualsNULL(startIndex);
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");
+        } else if (count != null && count == 0) {
+            return new GroupsGetResponse(0, Collections.emptyList());
         } else if (rootNode != null) {
             return filterGroups(rootNode, startIndex, count, sortBy, sortOrder, domainName, requiredAttributes);
         } else {
@@ -3259,9 +3261,7 @@ public class SCIMUserManager implements UserManager {
             throws NotImplementedException, CharonException, BadRequestException {
 
         // Handle count equals NULL scenario.
-        if (count == null) {
-            count = Integer.MAX_VALUE;
-        }
+        count = handleLimitEqualsNULL(count);
         if (rootNode instanceof ExpressionNode) {
             return filterGroupsBySingleAttribute((ExpressionNode) rootNode, startIndex, count, sortBy, sortOrder,
                     domainName, requiredAttributes);
@@ -3319,16 +3319,9 @@ public class SCIMUserManager implements UserManager {
 
             totalGroupCount = groupsList.size();
             // Adjust startIndex and endIndex to ensure they are within bounds
-            if (count < 0) {
-                count = 0;
-            }
-
             startIndex = Math.max(0, Math.min(startIndex - 1, totalGroupCount));
-            int endIndex = Math.min(startIndex + count, totalGroupCount);
-            // startIndex + count can cause integer overflow.
-            if (endIndex < 0) {
-                endIndex = totalGroupCount;
-            }
+            int endIndex = (count == 0 || count > Integer.MAX_VALUE - startIndex) ?
+                    totalGroupCount : Math.min(startIndex + count, totalGroupCount);
 
             groupsList = groupsList.subList(startIndex, endIndex);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -440,7 +440,7 @@ public class SCIMUserManagerTest {
         };
     }
 
-    @DataProvider(name = "groupPagination")
+    @DataProvider(name = "groupWithPagination")
     public Object[][] groupWithPagination() throws Exception {
 
         return new Object[][]{
@@ -524,7 +524,7 @@ public class SCIMUserManagerTest {
         assertEquals(groupsResponse.getGroups().size(), 1);
     }
 
-    @Test(dataProvider = "groupPagination")
+    @Test(dataProvider = "groupWithPagination")
     public void testFilterGroupsWithPagination(Integer startIndex, Integer count, Integer results, Integer totalResult)
             throws Exception {
 
@@ -566,7 +566,7 @@ public class SCIMUserManagerTest {
         userCoreUtil.close();
     }
 
-    @Test(dataProvider = "groupPagination")
+    @Test(dataProvider = "groupWithPagination")
     public void testListGroupsWithPagination(Integer startIndex, Integer count, Integer results, Integer totalResult)
             throws Exception {
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -537,6 +537,7 @@ public class SCIMUserManagerTest {
                 buildUserCoreGroupResponse("group6", "6", "dummyDomain")
         };
         String[] groups = new String[]{"group1", "group2", "group3", "group4", "group5", "group6"};
+        Node node = new ExpressionNode("filter urn:ietf:params:scim:schemas:core:2.0:Group:displayName co group");
 
         mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getRoleNames(anyString(), anyInt(), eq(false), eq(true), eq(true))).thenReturn(groups);
@@ -558,8 +559,8 @@ public class SCIMUserManagerTest {
         }
 
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(
-                new ExpressionNode("filter urn:ietf:params:scim:schemas:core:2.0:Group:displayName co group"), startIndex, count, null, null, null, null);
+        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(node, startIndex, count,
+                null, null, "PRIMARY", null);
 
         assertEquals(groupsResponse.getGroups().size(), results);
         assertEquals(groupsResponse.getTotalGroups(), totalResult);
@@ -583,9 +584,11 @@ public class SCIMUserManagerTest {
             when(mockedUserStoreManager.getGroupByGroupName(group, null)).
                     thenReturn(buildUserCoreGroupResponse(group, "123456789", null));
         }
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
+
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(null, startIndex, count, null, null,
-                null, null);
+        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(null, startIndex, count,
+                null, null, "PRIMARY", null);
 
         assertEquals(groupsResponse.getGroups().size(), results);
         assertEquals(groupsResponse.getTotalGroups(), totalResult);


### PR DESCRIPTION
### Purpose

1. Unifying count handling behaviour in groups listing as in users listing